### PR TITLE
add package metadata to mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,8 @@ defmodule Minesweeper.MixProject do
       version: "0.1.0",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      package: package()
     ]
   end
 
@@ -23,6 +24,15 @@ defmodule Minesweeper.MixProject do
     [
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+    ]
+  end
+
+  defp package do
+    [
+      description: "A minesweeper game",
+      licenses: ["MIT"],
+      links: %{"Github" => "https://github.com/lottetreg/minesweeper"},
+      source_url: "https://github.com/lottetreg/minesweeper"
     ]
   end
 end


### PR DESCRIPTION
The `package` metadata is required to publish to Hex