### PR TITLE
Circleci deploy workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,7 @@
 version: 2.1
-jobs:
-  build:
-    parallelism: 1
-    docker:
-      - image: circleci/elixir:1.8
-        environment:
-          MIX_ENV: test
 
-    working_directory: ~/minesweeper
-
+commands:
+  checkout_and_build:
     steps:
       - checkout
 
@@ -42,7 +35,65 @@ jobs:
           key: v1-build-cache
           paths: "_build"
 
+jobs:
+  test:
+    parallelism: 1
+    docker:
+      - image: circleci/elixir:1.8
+        environment:
+          MIX_ENV: test
+
+    working_directory: ~/minesweeper
+
+    steps:
+      - checkout_and_build
+
       - run: mix test
 
       - store_test_results:
           path: _build/test/lib/minesweeper
+
+  deploy:
+    docker:
+      - image: circleci/elixir:1.8
+
+    steps:
+      - checkout_and_build
+
+      - run:
+          name: Publish to Hex
+          # uses HEX_API_KEY
+          command: |
+            mix hex.publish --yes
+
+      - run:
+          name: Get Minesweeper Version
+          command: |
+            VERSION=`mix ex_app_info.version.get`
+            echo "export VERSION=$VERSION" >> $BASH_ENV
+            source $BASH_ENV
+            echo "Minesweeper Version is v${VERSION}"
+
+      - add_ssh_keys:
+          fingerprints:
+            - "7f:2b:da:23:1b:e3:11:76:7c:83:b7:c5:eb:40:25:e4"
+
+      - run:
+          name: Create and Push Git Tag
+          command: |
+            git config --global user.email "${GIT_USER_EMAIL}"
+            git config --global user.name "${GIT_USER_NAME}"
+            git tag -a v${VERSION} -m "v${VERSION}"
+            git push origin v${VERSION}
+
+workflows:
+  version: 2
+  test_and_deploy:
+    jobs:
+      - test
+      - deploy:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,8 @@ defmodule Minesweeper.MixProject do
   defp deps do
     [
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},
-      {:junit_formatter, "~> 3.0", only: [:test]}
+      {:junit_formatter, "~> 3.0", only: [:test]},
+      {:ex_app_info, "~> 0.3.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
+  "ex_app_info": {:hex, :ex_app_info, "0.3.0", "0c23240d8f7820f31bcd87d02cbe2fec4e5ab8d3d4a57100862d6fd25b137120", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "junit_formatter": {:hex, :junit_formatter, "3.0.0", "13950d944dbd295da7d8cc4798b8faee808a8bb9b637c88069954eac078ac9da", [:mix], [], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
If `master` passes the tests, publish to Hex and push a new git tag with the version specified in `mix.exs`.

Added the `ex_app_info` package to get the project's version non-interactively. 