### PR TITLE
add Mox

### DIFF
--- a/lib/behaviours/out_behaviour.ex
+++ b/lib/behaviours/out_behaviour.ex
@@ -1,0 +1,3 @@
+defmodule OutBehaviour do
+  @callback print(String.t()) :: none
+end

--- a/lib/out.ex
+++ b/lib/out.ex
@@ -1,4 +1,6 @@
 defmodule Out do
+  @behaviour OutBehaviour
+
   def print(string) do
     IO.puts(string)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -21,9 +21,10 @@ defmodule Minesweeper.MixProject do
 
   defp deps do
     [
+      {:ex_app_info, "~> 0.3.0"},
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},
       {:junit_formatter, "~> 3.0", only: [:test]},
-      {:ex_app_info, "~> 0.3.0"}
+      {:mox, "~> 0.5", only: :test}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -5,5 +5,6 @@
   "junit_formatter": {:hex, :junit_formatter, "3.0.0", "13950d944dbd295da7d8cc4798b8faee808a8bb9b637c88069954eac078ac9da", [:mix], [], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "mox": {:hex, :mox, "0.5.1", "f86bb36026aac1e6f924a4b6d024b05e9adbed5c63e8daa069bd66fb3292165b", [:mix], [], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
 }

--- a/test/game_test.exs
+++ b/test/game_test.exs
@@ -2,14 +2,16 @@ defmodule GameTest do
   use ExUnit.Case
   doctest Game
 
-  test "prints a 10x10 board" do
-    defmodule MockOut do
-      def print(string) do
-        send(self(), {:print, string})
-      end
-    end
+  import Mox
 
-    Game.print_board(MockOut)
+  setup :verify_on_exit!
+
+  test "prints a 10x10 board" do
+    out =
+      MockOut
+      |> expect(:print, 11, fn string -> send(self(), {:print, string}) end)
+
+    Game.print_board(out)
 
     assert_received {:print, "   A B C D E F G H I J"}
     assert_received {:print, "0 | | | | | | | | | | |"}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,4 @@
+Mox.defmock(MockOut, for: OutBehaviour)
+
 ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])
 ExUnit.start()


### PR DESCRIPTION
Mox: https://github.com/plataformatec/mox

Mox relies on [Typespecs](https://hexdocs.pm/elixir/typespecs.html) to enforce interfaces. Both `Out` and `MockOut` implement the `OutBehaviour` interface